### PR TITLE
Updating DefaultTimeout and PollIntervals for timeout prevention

### DIFF
--- a/api2captcha.go
+++ b/api2captcha.go
@@ -156,8 +156,8 @@ func NewClient(apiKey string) *Client {
 	return &Client{
 		BaseURL: base,
 		ApiKey:  apiKey,
-		DefaultTimeout: 5,
-		PollingInterval: 20,
+		DefaultTimeout: 20,
+		PollingInterval: 5,
 		RecaptchaTimeout: 600,
 		httpClient: &http.Client{},
 	}
@@ -168,8 +168,8 @@ func NewClientExt(apiKey string, client *http.Client) *Client {
 	return &Client{
 		BaseURL: base,
 		ApiKey:  apiKey,
-		DefaultTimeout: 5,
-		PollingInterval: 20,
+		DefaultTimeout: 20,
+		PollingInterval: 5,
 		RecaptchaTimeout: 600,
 		httpClient: client,
 	}

--- a/api2captcha.go
+++ b/api2captcha.go
@@ -156,8 +156,8 @@ func NewClient(apiKey string) *Client {
 	return &Client{
 		BaseURL: base,
 		ApiKey:  apiKey,
-		DefaultTimeout: 10,
-		PollingInterval: 10,
+		DefaultTimeout: 5,
+		PollingInterval: 20,
 		RecaptchaTimeout: 600,
 		httpClient: &http.Client{},
 	}
@@ -168,8 +168,8 @@ func NewClientExt(apiKey string, client *http.Client) *Client {
 	return &Client{
 		BaseURL: base,
 		ApiKey:  apiKey,
-		DefaultTimeout: 10,
-		PollingInterval: 10,
+		DefaultTimeout: 5,
+		PollingInterval: 20,
 		RecaptchaTimeout: 600,
 		httpClient: client,
 	}


### PR DESCRIPTION
Hey,

I realized that for hcaptcha, if requests takes more then enough to be solved and return `CAPCHA_NOT_READY`, it just polls one more time after 10 seconds, and if that still not ready dies. This has two downsides, 1st is; it keeps you waiting 10 more seconds which actually it might be ready in 3rd or 4th second and you keep waiting extra 6 seconds. 2nd is; if it still not solved after 10 seconds it dies.

I changed these numbers to 20 and 5 in which it polls every 5 seconds for 4 times and eliminates those downsides as much as possible. I tested and got significant positive effects on my code.

Thanks.